### PR TITLE
docs(EcoNewsController): document 415 Unsupported Media Type response…

### DIFF
--- a/core/src/main/java/greencity/constant/HttpStatuses.java
+++ b/core/src/main/java/greencity/constant/HttpStatuses.java
@@ -10,6 +10,8 @@ public final class HttpStatuses {
     public static final String NOT_FOUND = "Not Found";
     public static final String SEE_OTHER = "See Other";
     public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
+    public static final String UNSUPPORTED_MEDIA_TYPE = "Unsupported Media Type";
+
 
     HttpStatuses() {
     }

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -66,6 +66,7 @@ public class EcoNewsController {
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = HttpStatuses.CREATED,
             content = @Content(schema = @Schema(implementation = EcoNewsGenericDto.class))),
+            @ApiResponse(responseCode = "415", description = HttpStatuses.UNSUPPORTED_MEDIA_TYPE)
     })
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<EcoNewsGenericDto> save(


### PR DESCRIPTION
… and add new constant to HttpStatuses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to indicate that the EcoNews creation endpoint may return a 415 "Unsupported Media Type" response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->