### PR TITLE
403 code response in GET /econews/contentAndSourceForEcoNews/{id} is …

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -383,7 +383,8 @@ public class EcoNewsController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
-        @ApiResponse(responseCode = "401", description = HttpStatuses.FORBIDDEN),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
         @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND,
                     content = @Content(schema = @Schema(implementation = NotFoundException.class)))
     })


### PR DESCRIPTION
…documented in the response codes list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated API documentation to accurately distinguish between "Unauthorized" (401) and "Forbidden" (403) responses for the endpoint that retrieves eco news details by ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->