### PR TITLE
[82] 401 code response in GET /econews/byUserPage is documented in th…

### DIFF
--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -222,7 +222,8 @@ public class EcoNewsController {
     @Operation(summary = "Find all eco news by page.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
-        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST)
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED)
     })
     @GetMapping("/byUserPage")
     @ApiPageable


### PR DESCRIPTION
…e response codes list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to include HTTP 401 (Unauthorized) as a possible response for the endpoint that retrieves eco news by user page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->