### PR TITLE
[56] change 200(ok) response to 201(created) in documentation list fo…

### DIFF
--- a/core/src/main/java/greencity/controller/CategoryController.java
+++ b/core/src/main/java/greencity/controller/CategoryController.java
@@ -29,7 +29,7 @@ public class CategoryController {
      */
     @Operation(summary = "Save category")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED),
         @ApiResponse(responseCode = "303", description = HttpStatuses.SEE_OTHER),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
     })


### PR DESCRIPTION
…r category, post  /category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the documented HTTP response code for the "Save category" endpoint to accurately reflect a 201 (Created) status in the API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->