### PR TITLE
add delete event comment

### DIFF
--- a/core/src/main/java/greencity/controller/EventCommentController.java
+++ b/core/src/main/java/greencity/controller/EventCommentController.java
@@ -72,4 +72,18 @@ public class EventCommentController {
         eventCommentService.unlikeComment(commentId, user);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
+
+    @Operation(summary = "Delete comment of event")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "403", description = HttpStatuses.FORBIDDEN),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
+    })
+    @DeleteMapping("{commentId}")
+    public ResponseEntity<Void> deleteEventComment(@PathVariable("commentId") Long commentId,
+                                                  @Parameter(hidden = true) @CurrentUser UserVO user) {
+        eventCommentService.deleteComment(commentId, user);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/core/src/test/java/greencity/controller/EventCommentControllerTest.java
+++ b/core/src/test/java/greencity/controller/EventCommentControllerTest.java
@@ -1,6 +1,7 @@
 package greencity.controller;
 
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -99,5 +100,26 @@ class EventCommentControllerTest {
             .andExpect(status().isBadRequest());
 
         verify(eventCommentService, never()).save(any(), any(), any());
+    }
+
+    @Test
+    @WithMockUser(username = "user@example.com")
+    void testDeleteEventComment() throws Exception {
+        Long commentId = 1L;
+
+        mockMvc.perform(delete(CONTROLLER_LINK + "/{commentId}", commentId))
+            .andExpect(status().isOk());
+
+        verify(eventCommentService).deleteComment(eq(commentId), any(UserVO.class));
+    }
+
+    @Test
+    void testDeleteEventComment_whenNotAuthenticated() throws Exception {
+        Long commentId = 1L;
+
+        mockMvc.perform(delete(CONTROLLER_LINK + "/{commentId}", commentId))
+            .andExpect(status().isUnauthorized());
+
+        verify(eventCommentService, never()).deleteComment(any(), any());
     }
 }

--- a/service-api/src/main/java/greencity/service/EventCommentService.java
+++ b/service-api/src/main/java/greencity/service/EventCommentService.java
@@ -39,5 +39,18 @@ public interface EventCommentService {
      */
     void unlikeComment(Long commentId, UserVO user);
 
+    /**
+     * This method allows the current user to delete their own comment.
+     * If the user is not the author of the comment, an exception will be thrown.
+     * The comment is soft deleted by setting the deleted flag to true.
+     *
+     * @param commentId the ID of the event comment to delete
+     * @param user the user who is deleting the comment
+     * @throws greencity.exception.exceptions.BadRequestException if the comment is not found
+     * @throws greencity.exception.exceptions.UserHasNoPermissionToAccessException if the user is not the author of the comment
+     * @author Roman Diakov
+     */
+    void deleteComment(Long commentId, UserVO user);
+
     EventCommentVO findById(Long id);
 }

--- a/service/src/main/java/greencity/service/EventCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EventCommentServiceImpl.java
@@ -13,6 +13,7 @@ import greencity.entity.EventCommentLike;
 import greencity.entity.User;
 import greencity.enums.NotificationObjectType;
 import greencity.exception.exceptions.BadRequestException;
+import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
 import greencity.mapping.AddEventCommentDtoResponseMapper;
 import greencity.mapping.EventCommentMapper;
 import greencity.exception.exceptions.ConflictException;
@@ -143,5 +144,28 @@ public class EventCommentServiceImpl implements EventCommentService {
         EventComment eventComment = eventCommentRepo.findById(id).orElseThrow(
                 () -> new BadRequestException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
         return modelMapper.map(eventComment, EventCommentVO.class);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param commentId the ID of the event comment to delete
+     * @param user      the user who is deleting the comment
+     * @throws BadRequestException if the comment is not found
+     * @throws UserHasNoPermissionToAccessException if the user is not the author of the comment
+     * @author Roman Diakov
+     */
+    @Override
+    @Transactional
+    public void deleteComment(Long commentId, UserVO user) {
+        EventComment eventComment = eventCommentRepo.findById(commentId).orElseThrow(
+                () -> new BadRequestException(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION));
+
+        if (!eventComment.getUser().getId().equals(user.getId())) {
+            throw new UserHasNoPermissionToAccessException("You can only delete your own comments");
+        }
+
+        eventComment.setDeleted(true);
+        eventCommentRepo.save(eventComment);
     }
 }

--- a/service/src/test/java/greencity/service/EventCommentServiceImplTest.java
+++ b/service/src/test/java/greencity/service/EventCommentServiceImplTest.java
@@ -11,6 +11,7 @@ import greencity.dto.user.UserVO;
 import greencity.entity.EventComment;
 import greencity.entity.User;
 import greencity.exception.exceptions.BadRequestException;
+import greencity.exception.exceptions.UserHasNoPermissionToAccessException;
 import greencity.mapping.AddEventCommentDtoResponseMapper;
 import greencity.mapping.EventCommentMapper;
 import greencity.rating.RatingCalculation;
@@ -121,5 +122,53 @@ class EventCommentServiceImplTest {
             () -> eventCommentService.save(EVENT.getId(), request, USER));
         assertEquals(ErrorMessage.CANNOT_REPLY_THE_REPLY, actual.getMessage());
         verify(eventCommentRepository, never()).save(eventComment);
+    }
+
+    @Test
+    void testDeleteComment_success() {
+        Long commentId = 1L;
+        EventComment eventComment = new EventComment();
+        eventComment.setId(commentId);
+        User user = new User();
+        user.setId(USER.getId());
+        eventComment.setUser(user);
+
+        when(eventCommentRepository.findById(commentId)).thenReturn(Optional.of(eventComment));
+
+        eventCommentService.deleteComment(commentId, USER);
+
+        verify(eventCommentRepository).findById(commentId);
+        verify(eventCommentRepository).save(eventComment);
+        assertTrue(eventComment.getDeleted());
+    }
+
+    @Test
+    void testDeleteComment_commentNotFound() {
+        Long commentId = 1L;
+        when(eventCommentRepository.findById(commentId)).thenReturn(Optional.empty());
+
+        Exception exception = assertThrows(BadRequestException.class,
+            () -> eventCommentService.deleteComment(commentId, USER));
+        assertEquals(ErrorMessage.COMMENT_NOT_FOUND_EXCEPTION, exception.getMessage());
+        verify(eventCommentRepository).findById(commentId);
+        verify(eventCommentRepository, never()).save(any(EventComment.class));
+    }
+
+    @Test
+    void testDeleteComment_notAuthor() {
+        Long commentId = 1L;
+        EventComment eventComment = new EventComment();
+        eventComment.setId(commentId);
+        User user = new User();
+        user.setId(USER.getId() + 1);
+        eventComment.setUser(user);
+
+        when(eventCommentRepository.findById(commentId)).thenReturn(Optional.of(eventComment));
+
+        Exception exception = assertThrows(UserHasNoPermissionToAccessException.class,
+            () -> eventCommentService.deleteComment(commentId, USER));
+        assertEquals("You can only delete your own comments", exception.getMessage());
+        verify(eventCommentRepository).findById(commentId);
+        verify(eventCommentRepository, never()).save(any(EventComment.class));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for users to delete their own event comments.

- **Bug Fixes**
  - Improved error handling for unauthorized or invalid comment deletion attempts.

- **Tests**
  - Added unit and integration tests to ensure correct behavior and permission checks for comment deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->